### PR TITLE
Make odhcp6c more verbose

### DIFF
--- a/package/network/ipv6/odhcp6c/files/dhcpv6.sh
+++ b/package/network/ipv6/odhcp6c/files/dhcpv6.sh
@@ -104,7 +104,7 @@ proto_dhcpv6_setup() {
 
 	proto_export "INTERFACE=$config"
 	proto_run_command "$config" odhcp6c \
-		-s /lib/netifd/dhcpv6.script \
+		-s /lib/netifd/dhcpv6.script -v \
 		$opts $iface
 }
 


### PR DESCRIPTION
I had an issue with my ISP's DHCPv6 assignment that would have been easier to debug if odhcp6c was more verbose in logging. Given that much less critical information shows up in `logread`, and given that it's relatively hard to find the file above to modify, I vote for an increase in logging.

Here is what it adds to my logging (and you can see where the problem starts in my case, that is a failure to respond to the RENEW message):
```
root@OpenWrt:~# logread | grep odhcp6c
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: (re)starting transaction on eth1
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Starting SOLICIT transaction (timeout 4294967295s, max rc 0)
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 9ms
Fri Mar 30 10:42:43 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 45ms
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Starting REQUEST transaction (timeout 4294967295s, max rc 10)
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Send REQUEST message (elapsed 0ms, rc 0)
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Got a valid reply after 6ms
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: entering stateful-mode on eth1
Fri Mar 30 10:42:44 2018 daemon.notice odhcp6c[6439]: Starting <POLL> transaction (timeout 1200s, max rc 0)
Fri Mar 30 11:02:46 2018 daemon.notice odhcp6c[6439]: Starting RENEW transaction (timeout 600s, max rc 0)
Fri Mar 30 11:02:46 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 0ms, rc 0)
Fri Mar 30 11:02:56 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 10240ms, rc 1)
Fri Mar 30 11:03:16 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 30720ms, rc 2)
Fri Mar 30 11:03:57 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 71040ms, rc 3)
Fri Mar 30 11:05:19 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 153600ms, rc 4)
Fri Mar 30 11:08:03 2018 daemon.notice odhcp6c[6439]: Send RENEW message (elapsed 317440ms, rc 5)
```